### PR TITLE
Add `php` alias to avoid image build error

### DIFF
--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -19,11 +19,19 @@ jobs:
         token: ${{ secrets.API_TOKEN_GITHUB }}
     - name: Fetch upstream changes
       id: sync
-      uses: ivanmilov/upstream_check_new_commits@v1
+#      uses: ivanmilov/upstream_check_new_commits@v1
+#      with:
+#        upstream_repository: zotero/zotero
+#        upstream_branch: 6.0
+#        target_branch: 6.0
+
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
       with:
-        upstream_repository: zotero/zotero
-        upstream_branch: 6\.0
-        target_branch: 6\.0
+        target_sync_branch: 6.0
+        target_repo_token: ${{ secrets.API_TOKEN_GITHUB }}
+        upstream_sync_branch: 6.0
+        upstream_sync_repo: zotero/zotero
+
 
     outputs:
       newcommit: ${{ steps.sync.outputs.has_new_commits }}

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -19,18 +19,23 @@ jobs:
         token: ${{ secrets.API_TOKEN_GITHUB }}
     - name: Fetch upstream changes
       id: sync
+      run: |
+        git remote add upstream https://github.com/zotero/zotero
+        git pull upstream/6.0 6.0
+        git push origin 6.0
+
 #      uses: ivanmilov/upstream_check_new_commits@v1
 #      with:
 #        upstream_repository: zotero/zotero
 #        upstream_branch: 6.0
 #        target_branch: 6.0
 
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
-      with:
-        target_sync_branch: "6.0"
-        target_repo_token: ${{ secrets.API_TOKEN_GITHUB }}
-        upstream_sync_branch: 6.0
-        upstream_sync_repo: zotero/zotero
+#      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+#      with:
+#        target_sync_branch: 6.0
+#        target_repo_token: ${{ secrets.API_TOKEN_GITHUB }}
+#        upstream_sync_branch: 6.0
+#        upstream_sync_repo: zotero/zotero
 
 
     outputs:

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -27,7 +27,7 @@ jobs:
 
       uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
       with:
-        target_sync_branch: '6.0'
+        target_sync_branch: "6.0"
         target_repo_token: ${{ secrets.API_TOKEN_GITHUB }}
         upstream_sync_branch: 6.0
         upstream_sync_repo: zotero/zotero

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -23,7 +23,7 @@ jobs:
         git config pull.rebase true
         git remote add upstream https://github.com/zotero/zotero
         git fetch --all
-        git checkout 6.0
+        git checkout origin/6.0
         git pull upstream 6.0
         git push origin 6.0
 

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -21,6 +21,7 @@ jobs:
       id: sync
       run: |
         git remote add upstream https://github.com/zotero/zotero
+        git fetch --all
         git pull upstream/6.0 6.0
         git push origin 6.0
 

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -21,7 +21,6 @@ jobs:
       id: sync
       run: |
         git remote add upstream https://github.com/zotero/zotero
-#        git fetch --all
         git pull upstream 6.0
         git push origin 6.0
 

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -22,8 +22,8 @@ jobs:
       uses: ivanmilov/upstream_check_new_commits@v1
       with:
         upstream_repository: zotero/zotero
-        upstream_branch: 6.0
-        target_branch: 6.0
+        upstream_branch: '6.0'
+        target_branch: '6.0'
 
     outputs:
       newcommit: ${{ steps.sync.outputs.has_new_commits }}

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: 6.0
+        ref: origin/6.0
         repository: uniuuu/zotero
         token: ${{ secrets.API_TOKEN_GITHUB }}
     - name: Fetch upstream changes

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -27,7 +27,7 @@ jobs:
 
       uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
       with:
-        target_sync_branch: 6.0
+        target_sync_branch: '6.0'
         target_repo_token: ${{ secrets.API_TOKEN_GITHUB }}
         upstream_sync_branch: 6.0
         upstream_sync_repo: zotero/zotero

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: fregante/setup-git-user@v2
       - name: Checkout submodules
         run: |
-          git submodule update --init --recursive --remote client/zotero-client
+          git submodule update --init --recursive --remote
           git add -A
           git diff-index --quiet HEAD || git commit -m 'Github Actions Update Submodule client/zotero-client'
           git push origin development

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Check upstream latest commits
     steps:
-    - name: Checkout 6.0
+    - name: Checkout
       uses: actions/checkout@v4
       with:
+        ref: 6.0
         repository: uniuuu/zotero
         token: ${{ secrets.API_TOKEN_GITHUB }}
     - name: Fetch upstream changes
@@ -23,7 +24,6 @@ jobs:
         git config pull.rebase true
         git remote add upstream https://github.com/zotero/zotero
         git fetch --all
-        git checkout origin/6.0
         git pull upstream 6.0
         git push origin 6.0
 

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -22,8 +22,8 @@ jobs:
       uses: ivanmilov/upstream_check_new_commits@v1
       with:
         upstream_repository: zotero/zotero
-        upstream_branch: '6.0'
-        target_branch: '6.0'
+        upstream_branch: 6\.0
+        target_branch: 6\.0
 
     outputs:
       newcommit: ${{ steps.sync.outputs.has_new_commits }}

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -21,8 +21,9 @@ jobs:
       id: sync
       run: |
         git config pull.rebase true
-        git checkout 6.0
         git remote add upstream https://github.com/zotero/zotero
+        git fetch --all
+        git checkout 6.0
         git pull upstream 6.0
         git push origin 6.0
 

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Fetch upstream changes
       id: sync
       run: |
+        git config pull.rebase true
+        git checkout 6.0
         git remote add upstream https://github.com/zotero/zotero
         git pull upstream 6.0
         git push origin 6.0

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check upstream latest commits
     steps:
-    - name: Checkout main
+    - name: Checkout 6.0
       uses: actions/checkout@v4
       with:
         repository: uniuuu/zotero
@@ -22,8 +22,8 @@ jobs:
       uses: ivanmilov/upstream_check_new_commits@v1
       with:
         upstream_repository: zotero/zotero
-        upstream_branch: main
-        target_branch: main
+        upstream_branch: 6.0
+        target_branch: 6.0
 
     outputs:
       newcommit: ${{ steps.sync.outputs.has_new_commits }}
@@ -57,7 +57,7 @@ jobs:
       - uses: fregante/setup-git-user@v2
       - name: Checkout submodules
         run: |
-          git submodule update --init --recursive --remote
+          git submodule update --init --remote client/zotero-client
           git add -A
           git diff-index --quiet HEAD || git commit -m 'Github Actions Update Submodule client/zotero-client'
           git push origin development

--- a/.github/workflows/update-fork_zotero-client_update-submodule.yml
+++ b/.github/workflows/update-fork_zotero-client_update-submodule.yml
@@ -21,8 +21,8 @@ jobs:
       id: sync
       run: |
         git remote add upstream https://github.com/zotero/zotero
-        git fetch --all
-        git pull upstream/6.0 6.0
+#        git fetch --all
+        git pull upstream 6.0
         git push origin 6.0
 
 #      uses: ivanmilov/upstream_check_new_commits@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs
 docker-compose-test.yml
 **/cred.json
 .vscode/
+!/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ logs
 docker-compose-test.yml
 **/cred.json
 .vscode/
-!/.idea/
+.idea/

--- a/stack/dataserver/ds.Dockerfile
+++ b/stack/dataserver/ds.Dockerfile
@@ -3,7 +3,7 @@ ARG ZOTPRIME_VERSION=2
 RUN set -eux; \
         apk update && apk upgrade --available; \
         apk add --update --no-cache \
-        apache2 \   
+        apache2 \
         apache2-utils \
         aws-cli \
         bash \
@@ -70,6 +70,7 @@ RUN set -eux; \
         unzip \
         uwsgi \
         wget \
+        && ln -s /usr/bin/php81 /usr/bin/php \
         && rm -vrf /var/cache/apk/*
 
 FROM stage1 AS stage2


### PR DESCRIPTION
### Issue

The `/bin/sh: php: not found` error was thrown when building the `dataserver` image. 

```bash
...
1.384 + curl -sS https://getcomposer.org/installer
1.384 + php -- '--install-dir=/usr/local/bin' '--filename=composer'
1.384 /bin/sh: php: not found
1.544 curl: (23) Failure writing output to destination
------
ds.Dockerfile:77
--------------------
  76 |     FROM stage1 AS stage2
  77 | >>> RUN set -eux; \
  78 | >>>         apk update && apk upgrade --available \
  79 | >>>         && apk add --update --no-cache \
  80 | >>>         && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
  81 | >>>         && composer require --no-plugins --no-scripts pear/http_request2 \
  82 | >>>         && rm -rf /tmp/pear \
  83 | >>>         && rm -vrf /var/cache/apk/*
  84 |
--------------------
ERROR: failed to solve: process "/bin/sh -c set -eux;         apk update && apk upgrade --available         && apk add --update --no-cache         && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer         && composer require --no-plugins --no-scripts pear/http_request2         && rm -rf /tmp/pear         && rm -vrf /var/cache/apk/*" did not complete successfully: exit code: 127
```

### Candidate solution
After specifying the alias of `php` in docker file, the image build process was successful.

### Env
macOS Sonoma, 14.4 (23E214), M1
Docker version 25.0.3, build 4debf41
Docker Compose version v2.24.6-desktop.1