### PR TITLE
Fix client.Dockerfile/build error

### DIFF
--- a/client.Dockerfile
+++ b/client.Dockerfile
@@ -41,6 +41,7 @@ RUN set -eux; \
     git-lfs \
     grep \
     bash \
+    binutils \
     coreutils \
     curl \
     ncurses \


### PR DESCRIPTION
https://github.com/uniuuu/zotprime/issues/39

```bash
#26 12.72 Everything is Ok
#26 12.72
#26 12.72 Archives with Warnings: 1
#26 12.72
#26 12.72 Warnings: 1
#26 12.72 Folders: 9
#26 12.72 Files: 87
#26 12.72 Size:       218006509
#26 12.72 Compressed: 57040328
#26 12.73 /usr/src/app/client/zotero-client/app/xulrunner/firefox-win32 /usr/src/app/client/zotero-client/app/xulrunner
#26 13.41 strings: unrecognized option: e
#26 13.42 BusyBox v1.36.1 (2024-06-10 07:11:47 UTC) multi-call binary.
#26 13.42
#26 13.42 Usage: strings [-fo] [-t o|d|x] [-n LEN] [FILE]...
#26 13.42
#26 13.42 Display printable strings in a binary file
#26 13.42
#26 13.42 	-f		Precede strings with filenames
#26 13.42 	-o		Precede strings with octal offsets
#26 13.42 	-t o|d|x	Precede strings with offsets in base 8/10/16
#26 13.42 	-n LEN		At least LEN characters form a string (default 4)
#26 13.42 "Zotero" not found in xul.dll after replacement
#26 ERROR: process "/bin/sh -c set -eux;      app/scripts/dir_build -p $MLW" did not complete successfully: exit code: 1
------
 > [stage-2 10/10] RUN set -eux;      app/scripts/dir_build -p w:
13.42
13.42 Usage: strings [-fo] [-t o|d|x] [-n LEN] [FILE]...
13.42
13.42 Display printable strings in a binary file
13.42
13.42 	-f		Precede strings with filenames
13.42 	-o		Precede strings with octal offsets
13.42 	-t o|d|x	Precede strings with offsets in base 8/10/16
13.42 	-n LEN		At least LEN characters form a string (default 4)
13.42 "Zotero" not found in xul.dll after replacement
------
client.Dockerfile:77
--------------------
  76 |
  77 | >>> RUN set -eux; \
  78 | >>>      app/scripts/dir_build -p $MLW
  79 |
--------------------
ERROR: failed to solve: process "/bin/sh -c set -eux;      app/scripts/dir_build -p $MLW" did not complete successfully: exit code: 1
```