### PR TITLE
Add volume for object storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - "9000:9000"
       - "9001:9001"
     volumes:
+      - miniodata:/data
       - /etc/localtime:/etc/localtime:ro
     networks:
       zotprime:
@@ -153,6 +154,8 @@ services:
         ipv4_address: 10.5.5.11
 volumes:
   dbdata:
+   driver: local
+  miniodata:
    driver: local
 networks:
   zotprime:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,3 +164,4 @@ networks:
       config:
         - subnet: 10.5.5.0/28
           gateway: 10.5.5.1
+


### PR DESCRIPTION
It makes sense to persistently store the minio data in production environments so that in case of a reboot you do not need to fix some sync issues because the minio storage is not initialized and filled anymore.

Similiar to the db data i used the local driver.