### PR TITLE
install.sh: generate valid APP_KEY.

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -54,7 +54,7 @@ then
   WEBADMIN_USERNAME="webadmin"
   WEBADMIN_PASSWORD_PLAIN=$(openssl rand -hex 12)
   WEBADMIN_PASSWORD=$(php -r "echo password_hash('$WEBADMIN_PASSWORD_PLAIN', PASSWORD_BCRYPT, ['cost' => 12]);")
-  APP_KEY=$(openssl rand -hex 32)
+  APP_KEY=$(echo -n "base64:"; openssl rand -base64 32)
   PORTAL_SESSION_SECRET=$(openssl rand -hex 32)
   
   # Update .env (use printf to preserve $ characters in bcrypt hashes)


### PR DESCRIPTION
Hey, first of all, thank you for this easy-to-use package, finally I can self-host a zotero server :)
On my first setup the admin-panel for managing users threw an error about an "unsupported cipher or incorrect key length", and this is apparently caused by an incorrectly set `APP_KEY` variable.

This PR implements one (hopefully correct) way of generating the `APP_KEY`. It worked for me, but I have exactly zero experience with Laravel, so I hope this is the appropriate fix :)